### PR TITLE
Fix README formatting - needed for pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-===========================
+============================
 HDMF Documentation Utilities
-===========================
+============================
 
 *This project is under active development. Its content, API and behavior may change at any time. We mean it.*
 


### PR DESCRIPTION
Fix README formatting. This is needed for publishing on PyPI. PyPI complains if RST does not render correctly. 