### PR TITLE
Add helper class for creating RSTFigure

### DIFF
--- a/hdmf_docutils/doctools/rst.py
+++ b/hdmf_docutils/doctools/rst.py
@@ -612,8 +612,8 @@ class RSTToc:
             hidden: bool = False,
             numbered: bool = False,
             glob: bool = False,
-            includehidden = False,
-            reversed = False
+            includehidden: bool = False,
+            reversed: bool = False
     ):
         self.entries = entries if entries is not None else []
         self.caption = caption

--- a/hdmf_docutils/doctools/rst.py
+++ b/hdmf_docutils/doctools/rst.py
@@ -232,14 +232,13 @@ class RSTDocument(object):
         self.document += self.newline
 
     def add_figure(self,
-                   **kwargs):
+                   figure):
         """
         Add a Figure to the document
 
-        Parameters are the same as for RSTFigure
+        :param figure: RSTFigure to add to the document
         """
-        fig = RSTFigure(**kwargs)
-        fig.render(rst_doc=self)
+        figure.render(rst_doc=self)
 
     def add_sidebar(self, text, title, subtitle=None):
         """

--- a/hdmf_docutils/doctools/rst.py
+++ b/hdmf_docutils/doctools/rst.py
@@ -654,14 +654,14 @@ class RSTToc:
         """
         rst_doc = rst_doc if rst_doc is not None else RSTDocument()
         rst_doc += rst_doc.newline
-        rst_doc += ".. toc::"
+        rst_doc += ".. toctree::"
         rst_doc += rst_doc.newline
         if self.caption is not None:
-            rst_doc += (rst_doc.indent_text(':caption: %s' % self.caption) + rst_doc.newline)
+            rst_doc += (rst_doc.indent_text(":caption: %s" % self.caption) + rst_doc.newline)
         if self.name is not None:
-            rst_doc += (rst_doc.indent_text(':name: %s' % self.name) + rst_doc.newline)
+            rst_doc += (rst_doc.indent_text(":name: %s" % self.name) + rst_doc.newline)
         if self.maxdepth is not None:
-            rst_doc += (rst_doc.indent_text(':maxdepth: %i' % self.maxdepth) + rst_doc.newline)
+            rst_doc += (rst_doc.indent_text(":maxdepth: %i" % self.maxdepth) + rst_doc.newline)
 
         # Add all the bool options
         bool_options = {

--- a/hdmf_docutils/doctools/rst.py
+++ b/hdmf_docutils/doctools/rst.py
@@ -236,9 +236,10 @@ class RSTDocument(object):
         """
         Add a Figure to the document
 
-        :param figure: RSTFigure to add to the document
+        :param figure: RSTFigure to add to the document. If set to None then do nothing
         """
-        figure.render(rst_doc=self)
+        if figure is not None:
+            figure.render(rst_doc=self)
 
     def add_sidebar(self, text, title, subtitle=None):
         """

--- a/hdmf_docutils/generate_format_docs.py
+++ b/hdmf_docutils/generate_format_docs.py
@@ -280,7 +280,8 @@ def render_data_type_section(section,
                                     bbox_inches='tight',
                                     pad_inches=0)
                         plt.close()
-                        type_desc_doc.add_figure(img='./_format_auto_docs/'+rt+".*", alt=rt)
+                        type_desc_doc.add_figure(image_path='./_format_auto_docs/'+rt+".*",
+                                                 alt=rt)
                         if print_status:
                             PrintHelper.print("    " + rt + '-- RENDER OK.',
                                               PrintHelper.OKGREEN)

--- a/hdmf_docutils/generate_format_docs.py
+++ b/hdmf_docutils/generate_format_docs.py
@@ -11,7 +11,7 @@ import traceback
 import os
 
 from .doctools.rst import RSTSectionLabelHelper as LabelHelper
-from .doctools.rst import RSTDocument
+from .doctools.rst import RSTDocument, RSTFigure
 from .doctools.renderrst import SpecToRST, DataTypeSection
 from .doctools.output import PrintHelper, GitHashHelper
 
@@ -280,8 +280,7 @@ def render_data_type_section(section,
                                     bbox_inches='tight',
                                     pad_inches=0)
                         plt.close()
-                        type_desc_doc.add_figure(image_path='./_format_auto_docs/'+rt+".*",
-                                                 alt=rt)
+                        type_desc_doc.add_figure(RSTFigure(image_path='./_format_auto_docs/'+rt+".*", alt=rt))
                         if print_status:
                             PrintHelper.print("    " + rt + '-- RENDER OK.',
                                               PrintHelper.OKGREEN)


### PR DESCRIPTION
* Add ``RSTFigure`` helper class to simplify creating figures in RST documents and update API for``RSTDocument.add_figure`` 
* Add ``RSTToc`` helper class to simplify creating table of contents in an RST document and ad ``RSTDocment.add_toc``
* Define ``RSTDocument.__add__`` to combine documents via ``+``
* Define ``RSTDocument.__iadd__`` to add to a document vis ``+=``
* Define ``RSTDocument.__str__`` ``RSTTable.__str__`` so simplify print and conversion to string