### PR TITLE
Fix deprecation warning for add_stylesheet

### DIFF
--- a/hdmf_docutils/init_sphinx_extension_doc.py
+++ b/hdmf_docutils/init_sphinx_extension_doc.py
@@ -384,9 +384,9 @@ def setup(app):
     app.connect('builder-inited', run_doc_autogen)
     # overrides for wide tables in RTD theme
     try:
-        app.add_stylesheet("theme_overrides.css")  # Used by older version of Sphinx
-    except AttributeError:
         app.add_css_file("theme_overrides.css")  # Used by newer Sphinx versions
+    except AttributeError:
+        app.add_stylesheet("theme_overrides.css")  # Used by older version of Sphinx
 
 # -- Customize sphinx settings
 numfig = True


### PR DESCRIPTION
I think we should try to use the code supported by newer versions of Sphinx first, and fall back to the code supported by older versions. 